### PR TITLE
Update link to doc and remove Korean refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   You can translate either by letting the service identify the source language or by selecting a source language and then by selecting a target language, and a business domain. Domain translation is linguistically targeted these business domains:
   * *The News domain* - targeted at news articles and transcripts, it translates English to and from Arabic, Brazilian Portuguese, French, Italian, or Spanish. It also translates Spanish to and from French.
   * *The Conversational domain* - targeted at conversational colloquialisms, it translates English to and from Arabic, Brazilian Portuguese, French, Italian, or Spanish.
-  * *The Patent domain* - targeted at technical and legal terminology, it translates Brazilian Portuguese, Chinese, Korean, or Spanish to English.
+  * *The Patent domain* - targeted at technical and legal terminology, it translates Brazilian Portuguese, Chinese, or Spanish to English.
 
 Give it a try! Click the button below to fork into IBM DevOps Services and deploy your own copy of this application on Bluemix.
 
@@ -135,4 +135,4 @@ Give it a try! Click the button below to fork into IBM DevOps Services and deplo
 [service_url]: http://www.ibm.com/watson/developercloud/language-translator.html
 [getting_started]: https://www.youtube.com/watch?v=X95CMuQys-g
 [sign_up]: https://console.ng.bluemix.net/registration/
-[docs]: http://www.ibm.com/watson/developercloud/doc/language-translator
+[docs]: http://www.ibm.com/watson/developercloud/doc/language-translator/index.html

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
     <title>Language Translator</title>
     <meta name="og:title" content="IBM Watson Language Translator">
-    <meta name="og:description" content="The IBM Watson Language Translator service converts text input in one language into a destination language for the end user using background from domain-specific models. Translation is available among Arabic, Chinese, English, French, Korean, Portuguese, German, and Spanish (some languages may not be available for all domains).">
+    <meta name="og:description" content="The IBM Watson Language Translator service converts text input in one language into a destination language for the end user using background from domain-specific models. Translation is available among Arabic, Chinese, English, French, Portuguese, German, and Spanish (some languages may not be available for all domains).">
     <link href="css/watson-bootstrap-style.css" rel="stylesheet">
     <link href="css/browser-compatibility.css" rel="stylesheet">
 </head>
@@ -56,11 +56,11 @@
             </div>
             <div class="col-lg-10 col-md-10 col-sm-12">
                 <h1>Language Translator</h1>
-                <p>The IBM Watson Language Translator service converts text input in one language into a destination language for the end user using background from domain-specific models. Translation is available among Arabic, Chinese, English, French, Korean, Portuguese, German, and Spanish (some languages may not be available for all domains).</p>
+                <p>The IBM Watson Language Translator service converts text input in one language into a destination language for the end user using background from domain-specific models. Translation is available among Arabic, Chinese, English, French, Portuguese, German, and Spanish (some languages may not be available for all domains).</p>
                 <p><img src="images/link.svg" class="glyph"><strong>Resources:</strong></br>
                     <div class="resources">
                         <a href="http://www.ibm.com/watson/developercloud/language-translator/api/v2/">API Overview</a>
-                        <a href="http://www.ibm.com/watson/developercloud/doc/language-translator/">Documentation</a>
+                        <a href="http://www.ibm.com/watson/developercloud/doc/language-translator/index.html">Documentation</a>
                         <a href="https://github.com/watson-developer-cloud/language-translator-nodejs">Fork on Github</a>
                         <a class="base--button base--button_fill" href="https://console.ng.bluemix.net/registration/?target=/catalog/services/language-translator/">Start free in Bluemix</a>
                     </div>


### PR DESCRIPTION
Added index.html to the end of the links to the LT documentation and removed mention of Korean, which is not fully supported.