### PR TITLE
Reduce memory in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,4 +8,4 @@ applications:
   name: language-translator-demo
   command: npm start
   path: .
-  memory: 512M
+  memory: 256M


### PR DESCRIPTION
Reduce memory to 256MB in order to fit within the
free tier allowance.