### PR TITLE
Updated Node version for PSIRT Advisory 14286

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watson-developer-cloud": "^3.11.1"
   },
   "engines": {
-    "node": ">=8.0"
+    "node": ">=11.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
PSIRT Advisory requires a Node.js version update to address vulnerabilities