### PR TITLE
build: add character counter, bidirectional language switch arrow

### DIFF
--- a/public/demo.js
+++ b/public/demo.js
@@ -159,7 +159,7 @@ $(document).ready(function () {
   // Lang Service - End here
 
   // Set maximum form input length
-  var maxInputLength = 5000;
+  var maxInputLength = 10000;
   $(document).ready(function() {
     $('#home textarea').attr('maxlength', maxInputLength);
     $('#home .input-counter').html('0/' + maxInputLength);
@@ -180,6 +180,7 @@ $(document).ready(function () {
     $('#home2 textarea').val('');
     $('#profile textarea').val('');
     $('#profile2 textarea').val('');
+    $('#home .input-counter').html('0/' + maxInputLength);
     sourceLangSelect = 'Choose Language';
   });
 

--- a/public/demo.js
+++ b/public/demo.js
@@ -158,6 +158,19 @@ $(document).ready(function () {
   });
   // Lang Service - End here
 
+  // Set maximum form input length
+  var maxInputLength = 5000;
+  $(document).ready(function() {
+    $('#home textarea').attr('maxlength', maxInputLength);
+    $('#home .input-counter').html('0/' + maxInputLength);
+  });
+
+  // Update input character counter
+  $('#home textarea').on('input', function(){
+    var currentLength = $(this).val().length;
+    $('#home .input-counter').html(currentLength + '/' + maxInputLength);
+  });
+
   // Reset all the values on page
   $('#resetSpan').click(function (e) {
     e.preventDefault();

--- a/public/demo.js
+++ b/public/demo.js
@@ -129,6 +129,15 @@ $(document).ready(function () {
     getTranslation();
   });
 
+  // Bidirectional toggle for source and target languages
+  $('#sourceTargetLangSwitch').on('click', function(e) {
+    e.preventDefault();
+    var sourceLang = $.trim($('#dropdownMenuInput').text());
+    var targetLang = $.trim($('#dropdownMenuOutput').text());
+    $('#dropdownMenuInput').html('').html(targetLang + '<span class="caret"></span>');
+    $('#dropdownMenuOutput').html('').html(sourceLang + '<span class="caret"></span>');
+  });
+
   // Lang Service - Start - This set send request for lang service to detect language
   // setup timer value for function
   var typingTimer; //timer identifier

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -152,6 +152,7 @@
                     data-toggle="tab">Text</a></li>
                 <li role="presentation"><a href="#profile" aria-controls="profile" role="tab" data-toggle="tab">Rest
                     API</a></li>
+                <button style="margin: 0em; padding: 0em;" class="btn btn-secondary pull-right" type="button" id="sourceTargetLangSwitch">⇄</button>
               </ul>
               <div class="hr-tab"></div>
               <fieldset>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -160,6 +160,7 @@
                     <div class="tab-content">
                       <div role="tabpanel" class="tab-pane active" id="home">
                         <textarea></textarea>
+                        <span class='input-counter'></span>
                       </div>
                       <div role="tabpanel" class="tab-pane" id="profile">
                         <textarea disabled="disabled">Example of Rest API</textarea>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -161,7 +161,7 @@
                     <div class="tab-content">
                       <div role="tabpanel" class="tab-pane active" id="home">
                         <textarea></textarea>
-                        <span class='input-counter'></span>
+                        <span style="position: absolute; right: 1.5em; bottom: 0.5em;" class='input-counter'></span>
                       </div>
                       <div role="tabpanel" class="tab-pane" id="profile">
                         <textarea disabled="disabled">Example of Rest API</textarea>


### PR DESCRIPTION
Corresponding to parts of the LT Demo Redesign #2668 issue on the wdc-tracker.
https://github.ibm.com/mnlp/wdc-tracker/issues/2668

"Usee Carbon 10 and IBM Plex design language

Limit the number of characters a user can enter in the public demo to 10,000 and show GUI element, similar to Google. (If 10k char limit is reached offer the user a path to signup for the service)

Enable and bidirectional arrow allowing the user to switch between languages similar to our internal demo"